### PR TITLE
Add Step 1 log to report

### DIFF
--- a/workflows/regenie/regenie.nf
+++ b/workflows/regenie/regenie.nf
@@ -61,7 +61,9 @@ workflow REGENIE {
         regenie_step2_out = REGENIE_STEP2_GENE_TESTS.out.regenie_step2_by_phenotype
         regenie_step2_parsed_logs =  REGENIE_STEP2_GENE_TESTS.out.regenie_step2_parsed_logs
     }
-    emit: 
+    emit:
+    regenie_step1_out_ch
+    regenie_step1_parsed_logs_ch
     regenie_step2_out
     regenie_step2_parsed_logs
 }

--- a/workflows/single_variant_tests.nf
+++ b/workflows/single_variant_tests.nf
@@ -88,8 +88,9 @@ workflow SINGLE_VARIANT_TESTS {
 
     regenie_step2_out = REGENIE.out.regenie_step2_out
     regenie_step2_parsed_logs = REGENIE.out.regenie_step2_parsed_logs
-    //TODO return logs from step1
-    regenie_step1_parsed_logs_ch = Channel.empty()
+    //return logs from step1
+    regenie_step1_parsed_logs_ch = REGENIE.out.regenie_step1_parsed_logs_ch
+    regenie_step1_out_ch = REGENIE.out.regenie_step1_out_ch
 
     if (!run_interaction_tests) {
 


### PR DESCRIPTION
Currently the log from Step 1 is not reported in the output report.html file, even if step 1 was performed and the step1.log file exists in the output directory; the html *always* shows 'Regenie step 1 skipped' under the Regenie Step 1 Log section. My suggested changes address this bug so that the Regenie Step 1 Log is reported if step 1 was run. 

Additionally, I checked that if 'regenie_skip_predictions = true' in the config, Step 1 is correctly reported as 'Regenie step 1 skipped' with these modifications. 